### PR TITLE
.gitignore: add .bak and .sqlite3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,9 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Text backup files
+*.bak
+
+# Database
+*.sqlite3


### PR DESCRIPTION
This pull request updates the `.gitignore` file to include rules for ignoring `.bak` and `.sqlite3` files. These file types are typically generated during development or as part of database management and should not be tracked by version control.
